### PR TITLE
Do not throw when calling list() on missing term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 test/support/browser-test.js
 test/support/mocha.css
 test/support/mocha.js
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ node_js:
   - "6"
   - "8"
   - "10"
+before_install:
+  - npm i -g codecov
+after_failure:
+  - codecov
+after_success:
+  - codecov

--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -58,7 +58,7 @@ class Clownface {
   }
 
   list () {
-    if (!this.term) {
+    if (!this.term && this.terms.length > 0) {
       throw new Error('iterator over multiple terms is not supported')
     }
 
@@ -68,7 +68,7 @@ class Clownface {
       [Symbol.iterator]: () => {
         return {
           next: () => {
-            if (item.term.equals(ns.nil)) {
+            if (!item.term || item.term.equals(ns.nil)) {
               return { done: true }
             }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple but powerful graph traversing library",
   "main": "index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "standard && nyc mocha"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,7 @@
     "@rdfjs/namespace": "^1.0.0",
     "@rdfjs/parser-n3": "^1.1.2",
     "mocha": "^5.2.0",
+    "nyc": "^13.1.0",
     "rdf-ext": "^1.1.2",
     "rdf-store-dataset": "^1.0.0",
     "standard": "^12.0.1",

--- a/test/Clownface/list.js
+++ b/test/Clownface/list.js
@@ -60,4 +60,13 @@ describe('.list', () => {
     assert(touched)
     assert(!list)
   })
+
+  it('should return empty iterator when no list exists', () => {
+    const cf = clownface(listGraph())
+
+    const list = cf.out(rdf.namedNode('http://example.com/not-list')).list()[Symbol.iterator]()
+
+    const first = list.next()
+    assert.strictEqual(first.done, true)
+  })
 })


### PR DESCRIPTION
## Current state

```
<> :list () .
<> :list () .
```

Having the graph above, Clownface throws the same error in two cases (pseudo rdf-ext below)

```js
cf(dataset).node('<>').out(':list').list()
```

```js
cf(dataset).node('<>').out(':something-else').list()
```

Both calls will throw `iterator over multiple terms is not supported` which actually only applies to the first line

## Desired state

This PR changes the implementation so that an iterator which will end immediately without returning anything.