### PR TITLE
use matching xsd datatypes for JS primitive types 

### DIFF
--- a/lib/fromPrimitive.js
+++ b/lib/fromPrimitive.js
@@ -1,0 +1,41 @@
+const rdf = require('@rdfjs/data-model')
+const namespace = require('@rdfjs/namespace')
+
+const xsd = namespace('http://www.w3.org/2001/XMLSchema#')
+
+function booleanToLiteral (value, factory = rdf) {
+  if (typeof value !== 'boolean') {
+    return null
+  }
+
+  return factory.literal(value.toString(), xsd('boolean'))
+}
+
+function numberToLiteral (value, factory = rdf) {
+  if (typeof value !== 'number') {
+    return null
+  }
+
+  return factory.literal(value.toString(10), xsd('double'))
+}
+
+function stringToLiteral (value, factory = rdf) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  return factory.literal(value)
+}
+
+function toLiteral (value, factory = rdf) {
+  return booleanToLiteral(value, factory) ||
+    numberToLiteral(value, factory) ||
+    stringToLiteral(value, factory)
+}
+
+module.exports = {
+  booleanToLiteral,
+  numberToLiteral,
+  stringToLiteral,
+  toLiteral
+}

--- a/lib/fromPrimitive.js
+++ b/lib/fromPrimitive.js
@@ -16,6 +16,10 @@ function numberToLiteral (value, factory = rdf) {
     return null
   }
 
+  if (Number.isInteger(value)) {
+    return factory.literal(value.toString(10), xsd('integer'))
+  }
+
   return factory.literal(value.toString(10), xsd('double'))
 }
 

--- a/lib/term.js
+++ b/lib/term.js
@@ -1,4 +1,5 @@
 const rdf = require('@rdfjs/data-model')
+const { toLiteral } = require('./fromPrimitive')
 
 function blankNode (value) {
   if (value && typeof value !== 'string') {
@@ -9,18 +10,24 @@ function blankNode (value) {
 }
 
 function literal (value, languageOrDatatype) {
-  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+  if (typeof value === 'string') {
+    // check if it's given, if given try RDF/JS Term value otherwise convert it to a string
+    languageOrDatatype = languageOrDatatype && (languageOrDatatype.value || languageOrDatatype.toString())
+
+    if (languageOrDatatype && languageOrDatatype.indexOf(':') !== -1) {
+      languageOrDatatype = rdf.namedNode(languageOrDatatype)
+    }
+
+    return rdf.literal(value.toString(), languageOrDatatype)
+  }
+
+  const term = toLiteral(value, rdf)
+
+  if (!term) {
     throw new Error('The value cannot be converted to a literal node')
   }
 
-  // check if it's given, if given try RDF/JS Term value otherwise convert it to a string
-  languageOrDatatype = languageOrDatatype && (languageOrDatatype.value || languageOrDatatype.toString())
-
-  if (languageOrDatatype && languageOrDatatype.indexOf(':') !== -1) {
-    languageOrDatatype = rdf.namedNode(languageOrDatatype)
-  }
-
-  return rdf.literal(value.toString(), languageOrDatatype)
+  return term
 }
 
 function namedNode (value) {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/rdf-ext/clownface",
   "dependencies": {
-    "@rdfjs/data-model": "^1.1.0"
+    "@rdfjs/data-model": "^1.1.0",
+    "@rdfjs/namespace": "^1.0.0"
   },
   "devDependencies": {
-    "@rdfjs/namespace": "^1.0.0",
     "@rdfjs/parser-n3": "^1.1.2",
     "mocha": "^5.2.0",
     "nyc": "^13.1.0",

--- a/test/Clownface/literal.js
+++ b/test/Clownface/literal.js
@@ -58,7 +58,8 @@ describe('.literal', () => {
 
     assert.strictEqual(result._context.length, 1)
     assert.strictEqual(result._context[0].term.termType, 'Literal')
-    assert.strictEqual(result._context[0].term.value, value.toString())
+    assert.strictEqual(result._context[0].term.value, value.toString(10))
+    assert.strictEqual(result._context[0].term.datatype.value, 'http://www.w3.org/2001/XMLSchema#double')
   })
 
   it('should use the given boolean as Literal', () => {
@@ -70,6 +71,7 @@ describe('.literal', () => {
     assert.strictEqual(result._context.length, 1)
     assert.strictEqual(result._context[0].term.termType, 'Literal')
     assert.strictEqual(result._context[0].term.value, value.toString())
+    assert.strictEqual(result._context[0].term.datatype.value, 'http://www.w3.org/2001/XMLSchema#boolean')
   })
 
   it('should support multiple values in an array', () => {

--- a/test/Clownface/literal.js
+++ b/test/Clownface/literal.js
@@ -50,8 +50,8 @@ describe('.literal', () => {
     assert.strictEqual(result._context[0].term.value, value)
   })
 
-  it('should use the given number as Literal', () => {
-    const value = 123
+  it('should use the given double number as Literal', () => {
+    const value = 1.23
     const cf = clownface(graph)
 
     const result = cf.literal(value)
@@ -60,6 +60,18 @@ describe('.literal', () => {
     assert.strictEqual(result._context[0].term.termType, 'Literal')
     assert.strictEqual(result._context[0].term.value, value.toString(10))
     assert.strictEqual(result._context[0].term.datatype.value, 'http://www.w3.org/2001/XMLSchema#double')
+  })
+
+  it('should use the given integer number as Literal', () => {
+    const value = 123
+    const cf = clownface(graph)
+
+    const result = cf.literal(value)
+
+    assert.strictEqual(result._context.length, 1)
+    assert.strictEqual(result._context[0].term.termType, 'Literal')
+    assert.strictEqual(result._context[0].term.value, value.toString(10))
+    assert.strictEqual(result._context[0].term.datatype.value, 'http://www.w3.org/2001/XMLSchema#integer')
   })
 
   it('should use the given boolean as Literal', () => {

--- a/test/fromPrimitive.js
+++ b/test/fromPrimitive.js
@@ -1,0 +1,78 @@
+/* global describe, it */
+
+const assert = require('assert')
+const namespace = require('@rdfjs/namespace')
+const rdf = require('./support/factory')
+const { booleanToLiteral, numberToLiteral, stringToLiteral, toLiteral } = require('../lib/fromPrimitive')
+
+const xsd = namespace('http://www.w3.org/2001/XMLSchema#')
+
+describe('fromPrimitive', () => {
+  describe('booleanToLiteral', () => {
+    it('is function', () => {
+      assert.strictEqual(typeof booleanToLiteral, 'function')
+    })
+
+    it('returns null if non boolean value is given', () => {
+      assert.strictEqual(booleanToLiteral(3), null)
+    })
+
+    it('returns Literal with xsd:boolean datatype for true value', () => {
+      assert(rdf.literal('true', xsd.boolean), booleanToLiteral(true))
+    })
+
+    it('returns Literal with xsd:boolean datatype for false value', () => {
+      assert(rdf.literal('false', xsd.boolean), booleanToLiteral(false))
+    })
+  })
+
+  describe('numberToLiteral', () => {
+    it('is function', () => {
+      assert.strictEqual(typeof numberToLiteral, 'function')
+    })
+
+    it('returns null if non number value is given', () => {
+      assert.strictEqual(numberToLiteral(true), null)
+    })
+
+    it('returns Literal with xsd:double datatype for number value', () => {
+      assert(rdf.literal('3.21', xsd.double).equals(numberToLiteral(3.21)))
+    })
+  })
+
+  describe('stringToLiteral', () => {
+    it('is function', () => {
+      assert.strictEqual(typeof stringToLiteral, 'function')
+    })
+
+    it('returns null if non string value is given', () => {
+      assert.strictEqual(stringToLiteral(true), null)
+    })
+
+    it('returns Literal', () => {
+      assert(rdf.literal('M42').equals(stringToLiteral('M42')))
+    })
+  })
+
+  describe('toLiteral', () => {
+    it('is function', () => {
+      assert.strictEqual(typeof toLiteral, 'function')
+    })
+
+    it('returns null if a value with an unknown type is given', () => {
+      assert.strictEqual(toLiteral({}), null)
+    })
+
+    it('returns Literal with xsd:boolean datatype for a boolean value', () => {
+      assert(rdf.literal('true', xsd.boolean), toLiteral(true))
+    })
+
+    it('returns Literal with xsd:double datatype for a number value', () => {
+      assert(rdf.literal('3.21', xsd.double).equals(toLiteral(3.21)))
+    })
+
+    it('returns Literal', () => {
+      assert(rdf.literal('M42').equals(toLiteral('M42')))
+    })
+  })
+})

--- a/test/fromPrimitive.js
+++ b/test/fromPrimitive.js
@@ -38,6 +38,10 @@ describe('fromPrimitive', () => {
     it('returns Literal with xsd:double datatype for number value', () => {
       assert(rdf.literal('3.21', xsd.double).equals(numberToLiteral(3.21)))
     })
+
+    it('returns Literal with xsd:integer datatype for a number value that is an integer', () => {
+      assert(rdf.literal('321', xsd.integer).equals(numberToLiteral(321)))
+    })
   })
 
   describe('stringToLiteral', () => {


### PR DESCRIPTION
fixes #10 