### PR TITLE
use named arguments in factory

### DIFF
--- a/examples/namespace.js
+++ b/examples/namespace.js
@@ -6,7 +6,7 @@ initExample().then(dataset => {
   const people = namespace('http://localhost:8080/data/person/')
   const schema = namespace('http://schema.org/')
 
-  const tbbt = clownface({ dataset} )
+  const tbbt = clownface({ dataset })
 
   const stuartBloom = tbbt.node(people('stuart-bloom'))
 

--- a/examples/namespace.js
+++ b/examples/namespace.js
@@ -6,7 +6,7 @@ initExample().then(dataset => {
   const people = namespace('http://localhost:8080/data/person/')
   const schema = namespace('http://schema.org/')
 
-  const tbbt = clownface(dataset)
+  const tbbt = clownface({ dataset} )
 
   const stuartBloom = tbbt.node(people('stuart-bloom'))
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,7 @@
 const Clownface = require('./lib/Clownface')
 
-function factory (dataset, nodes) {
-  return new Clownface(dataset, nodes)
-}
-
-factory.dataset = (dataset, nodes) => {
-  console.error(new Error('clownface.dataset(...) is deprecated, just call clownface(...)'))
-
-  return factory(dataset, nodes)
+function factory ({ dataset, graph, term, value, _context }) {
+  return new Clownface({ dataset, graph, term, value, _context })
 }
 
 module.exports = factory

--- a/lib/Clownface.js
+++ b/lib/Clownface.js
@@ -5,18 +5,18 @@ const toTermArray = require('./toTermArray')
 const Context = require('./Context')
 
 class Clownface {
-  constructor (dataset, values, graphs, { context } = {}) {
-    if (context) {
-      this._context = context
+  constructor ({ dataset, graph, term, value, _context }) {
+    if (_context) {
+      this._context = _context
 
       return
     }
 
-    this._context = toArray(graphs, [null]).reduce((all, graph) => {
-      return all.concat(toArray(values, [null]).reduce((all, value) => {
-        return all.concat([new Context(dataset, graph, value)])
-      }, []))
-    }, [])
+    const terms = (term && toArray(term)) || (value && toArray(value)) || [null]
+
+    this._context = terms.map(term => {
+      return new Context(dataset, graph, term)
+    })
   }
 
   get term () {
@@ -238,7 +238,7 @@ class Clownface {
   }
 
   static fromContext (context) {
-    return new Clownface(null, null, null, { context: toArray(context) })
+    return new Clownface({ _context: toArray(context) })
   }
 }
 

--- a/test/Clownface/addIn.js
+++ b/test/Clownface/addIn.js
@@ -1,31 +1,21 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const { addAll } = require('rdf-dataset-ext')
 
 describe('.addIn', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.addIn, 'function')
   })
 
   it('should throw an error if predicate parameter is missing', () => {
-    const localGraph = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset: rdf.dataset(), term: object })
 
     let touched = false
 
@@ -39,77 +29,77 @@ describe('.addIn', () => {
   })
 
   it('should add quads using the context term as object and the given predicate and subject', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
     cf.addIn(predicate, subject)
 
-    const result = localGraph.match(subject, predicate, object)
+    const result = dataset.match(subject, predicate, object)
 
     assert.strictEqual(result.size, 1)
   })
 
   it('should create a Blank Node subject if no subject was given', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
     cf.addIn(predicate)
 
-    const result = localGraph.match(null, predicate, object)
+    const result = dataset.match(null, predicate, object)
 
     assert.strictEqual(result.size, 1)
     assert.strictEqual([...result][0].subject.termType, 'BlankNode')
   })
 
   it('should support array values as predicate', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const predicateA = rdf.namedNode('http://schema.org/knows')
     const predicateB = rdf.namedNode('http://schema.org/saw')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
     cf.addIn([predicateA, predicateB], subject)
 
     const result = addAll(
-      localGraph.match(subject, predicateA, object),
-      localGraph.match(subject, predicateB, object))
+      dataset.match(subject, predicateA, object),
+      dataset.match(subject, predicateB, object))
 
     assert.strictEqual(result.size, 2)
   })
 
   it('should support array values as subject', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subjectA = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const subjectB = rdf.namedNode('http://localhost:8080/data/person/penny')
     const predicate = rdf.namedNode('http://schema.org/saw')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
     cf.addIn(predicate, [subjectA, subjectB])
 
     const result = addAll(
-      localGraph.match(subjectA, predicate, object),
-      localGraph.match(subjectB, predicate, object))
+      dataset.match(subjectA, predicate, object),
+      dataset.match(subjectB, predicate, object))
 
     assert.strictEqual(result.size, 2)
   })
 
   it('should call the given function with a context for all added subjects', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subjectA = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const subjectB = rdf.namedNode('http://localhost:8080/data/person/penny')
     const predicateA = rdf.namedNode('http://schema.org/knows')
     const predicateB = rdf.namedNode('http://schema.org/saw')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
-    let result
+    let result = null
 
     cf.addIn([predicateA, predicateB], [subjectA, subjectB], child => {
       result = child.values
@@ -119,12 +109,12 @@ describe('.addIn', () => {
   })
 
   it('should call the given function with a Blank Node context for the created subject', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
-    let result
+    let result = null
 
     cf.addIn(predicate, child => {
       result = child
@@ -135,25 +125,25 @@ describe('.addIn', () => {
   })
 
   it('should support clownface objects as predicate and subject', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
     cf.addIn(cf.node(predicate), cf.node(subject))
 
-    const result = localGraph.match(subject, predicate, object)
+    const result = dataset.match(subject, predicate, object)
 
     assert.strictEqual(result.size, 1)
   })
 
   it('should return the called object', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, object)
+    const cf = clownface({ dataset, term: object })
 
     assert.strictEqual(cf.addIn(predicate, subject), cf)
   })

--- a/test/Clownface/addList.js
+++ b/test/Clownface/addList.js
@@ -1,31 +1,22 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
-const ns = require('../support/namespace')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
+const ns = require('../support/namespace')
 
 describe('.addList', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.addList, 'function')
   })
 
   it('should throw an error if object parameter is missing', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/knows')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     let touched = false
 
@@ -39,10 +30,10 @@ describe('.addList', () => {
   })
 
   it('should throw an error if predicate parameter is missing', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     let touched = false
 
@@ -56,20 +47,20 @@ describe('.addList', () => {
   })
 
   it('should add list quads using the context term as subject and the given predicate and items', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/counts')
     const item0 = rdf.literal('0')
     const item1 = rdf.literal('1')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     cf.addList(predicate, [item0, item1])
 
-    const entry = [...localGraph.match(subject, predicate)][0]
-    const first0 = [...localGraph.match(entry.object, ns.first, item0)][0]
-    const rest0 = [...localGraph.match(entry.object, ns.rest)][0]
-    const first1 = [...localGraph.match(rest0.object, ns.first, item1)][0]
-    const rest1 = [localGraph.match(rest0.object, ns.rest, ns.nil)][0]
+    const entry = [...dataset.match(subject, predicate)][0]
+    const first0 = [...dataset.match(entry.object, ns.first, item0)][0]
+    const rest0 = [...dataset.match(entry.object, ns.rest)][0]
+    const first1 = [...dataset.match(rest0.object, ns.first, item1)][0]
+    const rest1 = [...dataset.match(rest0.object, ns.rest, ns.nil)][0]
 
     assert(entry)
     assert.strictEqual(entry.object.termType, 'BlankNode')

--- a/test/Clownface/addOut.js
+++ b/test/Clownface/addOut.js
@@ -1,31 +1,23 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const { addAll } = require('rdf-dataset-ext')
 
 describe('.addOut', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.addOut, 'function')
   })
 
-  it('should throw an error if predicate parameter is missing', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
+  it('should throw an error if predicate parameter is missing', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     let touched = false
 
@@ -38,78 +30,78 @@ describe('.addOut', () => {
     assert(touched)
   })
 
-  it('should add quads using the context term as subject and the given predicate and object', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
+  it('should add quads using the context term as subject and the given predicate and object', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     cf.addOut(predicate, object)
 
-    const result = localGraph.match(subject, predicate, object)
+    const result = dataset.match(subject, predicate, object)
 
     assert.strictEqual(result.size, 1)
   })
 
   it('should create a Blank Node subject if no subject was given', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/knows')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     cf.addOut(predicate)
 
-    const result = localGraph.match(subject, predicate)
+    const result = dataset.match(subject, predicate)
 
     assert.strictEqual(result.size, 1)
     assert.strictEqual([...result][0].object.termType, 'BlankNode')
   })
 
   it('should support array values as predicate', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicateA = rdf.namedNode('http://schema.org/knows')
     const predicateB = rdf.namedNode('http://schema.org/saw')
     const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     cf.addOut([predicateA, predicateB], object)
 
     const result = addAll(
-      localGraph.match(subject, predicateA, object),
-      localGraph.match(subject, predicateB, object))
+      dataset.match(subject, predicateA, object),
+      dataset.match(subject, predicateB, object))
 
     assert.strictEqual(result.size, 2)
   })
 
   it('should support array values as object', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/saw')
     const objectA = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const objectB = rdf.namedNode('http://localhost:8080/data/person/penny')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     cf.addOut(predicate, [objectA, objectB])
 
     const result = addAll(
-      localGraph.match(subject, predicate, objectA),
-      localGraph.match(subject, predicate, objectB))
+      dataset.match(subject, predicate, objectA),
+      dataset.match(subject, predicate, objectB))
 
     assert.strictEqual(result.size, 2)
   })
 
   it('should call the given function with a context for all added objects', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicateA = rdf.namedNode('http://schema.org/knows')
     const predicateB = rdf.namedNode('http://schema.org/saw')
     const objectA = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
     const objectB = rdf.namedNode('http://localhost:8080/data/person/penny')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
-    let result
+    let result = null
 
     cf.addOut([predicateA, predicateB], [objectA, objectB], child => {
       result = child.values
@@ -119,12 +111,12 @@ describe('.addOut', () => {
   })
 
   it('should call the given function with a Blank Node context for the created subject', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/knows')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
-    let result
+    let result = null
 
     cf.addOut(predicate, child => {
       result = child
@@ -135,25 +127,25 @@ describe('.addOut', () => {
   })
 
   it('should support clownface objects as predicate and object', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     cf.addOut(cf.node(predicate), cf.node(object))
 
-    const result = localGraph.match(subject, predicate, object)
+    const result = dataset.match(subject, predicate, object)
 
     assert.strictEqual(result.size, 1)
   })
 
   it('should return the called object', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/knows')
     const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({ dataset, term: subject })
 
     assert.strictEqual(cf.addOut(predicate, object), cf)
   })

--- a/test/Clownface/blankNode.js
+++ b/test/Clownface/blankNode.js
@@ -1,27 +1,19 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
-const initExample = require('../support/example')
+const rdf = require('../support/factory')
 const Clownface = require('../../lib/Clownface')
 
 describe('.blankNode', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.blankNode, 'function')
   })
 
   it('should return a new Clownface instance', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.blankNode()
 
@@ -30,15 +22,16 @@ describe('.blankNode', () => {
   })
 
   it('should use the dataset from the context', () => {
-    const cf = clownface(graph)
+    const dataset = rdf.dataset()
+    const cf = clownface({ dataset })
 
     const result = cf.blankNode()
 
-    assert.strictEqual(result._context[0].dataset, graph)
+    assert.strictEqual(result._context[0].dataset, dataset)
   })
 
   it('should create a context with a Blank Node term', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.blankNode()
 
@@ -48,7 +41,7 @@ describe('.blankNode', () => {
 
   it('should use the given label for the Blank Node', () => {
     const label = 'b321'
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.blankNode(label)
 
@@ -60,7 +53,7 @@ describe('.blankNode', () => {
   it('should support multiple values in an array', () => {
     const labelA = 'b321a'
     const labelB = 'b321b'
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.blankNode([labelA, labelB])
 

--- a/test/Clownface/constructor.js
+++ b/test/Clownface/constructor.js
@@ -1,0 +1,124 @@
+/* global describe, it */
+
+const assert = require('assert')
+const rdf = require('../support/factory')
+const Clownface = require('../../lib/Clownface')
+
+describe('constructor', () => {
+  it('should create a Clownface object', () => {
+    const dataset = rdf.dataset()
+    const cf = new Clownface({ dataset })
+
+    assert(cf instanceof Clownface)
+  })
+
+  it('should create an empty context using the given dataset', () => {
+    const dataset = rdf.dataset()
+    const cf = new Clownface({ dataset })
+
+    assert.strictEqual(cf._context.length, 1)
+    assert.strictEqual(cf._context[0].dataset, dataset)
+    assert(!cf._context[0].graph)
+    assert(!cf._context[0].term)
+  })
+
+  it('should create an empty context using the given graph', () => {
+    const dataset = rdf.dataset()
+    const graph = rdf.namedNode('http://example.org/graph')
+    const cf = new Clownface({ dataset, graph })
+
+    assert.strictEqual(cf._context.length, 1)
+    assert.strictEqual(cf._context[0].dataset, dataset)
+    assert.strictEqual(cf._context[0].graph, graph)
+    assert(!cf._context[0].term)
+  })
+
+  it('should create a context using the given term', () => {
+    const dataset = rdf.dataset()
+    const term = rdf.namedNode('http://example.org/subject')
+    const cf = new Clownface({ dataset, term })
+
+    assert.strictEqual(cf._context.length, 1)
+    assert.strictEqual(cf._context[0].term, term)
+  })
+
+  it('should create a context using the given terms', () => {
+    const dataset = rdf.dataset()
+    const termA = rdf.namedNode('http://example.org/subjectA')
+    const termB = rdf.namedNode('http://example.org/subjectB')
+    const cf = new Clownface({ dataset, term: [termA, termB] })
+
+    assert.strictEqual(cf._context.length, 2)
+    assert.strictEqual(cf._context[0].term, termA)
+    assert.strictEqual(cf._context[1].term, termB)
+  })
+
+  it('should create a context using the given value', () => {
+    const dataset = rdf.dataset()
+    const value = 'abc'
+    const cf = new Clownface({ dataset, value })
+
+    assert.strictEqual(cf._context.length, 1)
+    assert.strictEqual(cf._context[0].term.termType, 'Literal')
+    assert.strictEqual(cf._context[0].term.value, value)
+  })
+
+  it('should create a context using the given values', () => {
+    const dataset = rdf.dataset()
+    const valueA = 'abc'
+    const valueB = 'bcd'
+    const cf = new Clownface({ dataset, value: [valueA, valueB] })
+
+    assert.strictEqual(cf._context.length, 2)
+    assert.strictEqual(cf._context[0].term.termType, 'Literal')
+    assert.strictEqual(cf._context[0].term.value, valueA)
+    assert.strictEqual(cf._context[1].term.termType, 'Literal')
+    assert.strictEqual(cf._context[1].term.value, valueB)
+  })
+
+  it('should prioritize term over value', () => {
+    const dataset = rdf.dataset()
+    const termA = rdf.namedNode('http://example.org/subjectA')
+    const termB = rdf.namedNode('http://example.org/subjectB')
+    const valueA = 'abc'
+    const valueB = 'bcd'
+    const cf = new Clownface({ dataset, term: [termA, termB], value: [valueA, valueB] })
+
+    assert.strictEqual(cf._context.length, 2)
+    assert.strictEqual(cf._context[0].term, termA)
+    assert.strictEqual(cf._context[1].term, termB)
+  })
+
+  it('should use the given _context', () => {
+    const dataset = rdf.dataset()
+    const term = rdf.namedNode('http://example.org/subject')
+    const cf = new Clownface({ dataset, term })
+    const clone = new Clownface(cf)
+
+    assert.strictEqual(clone._context, cf._context)
+  })
+
+  it('should prioritize _context over term', () => {
+    const dataset = rdf.dataset()
+    const term = rdf.namedNode('http://example.org/subject')
+    const cf = new Clownface({ dataset, term })
+    const clone = new Clownface({ term, _context: cf._context })
+
+    assert.strictEqual(clone._context, cf._context)
+  })
+
+  it('should throw an error if an unknown type is given as value', () => {
+    const dataset = rdf.dataset()
+
+    let error = null
+
+    try {
+      Boolean(new Clownface({ dataset, value: new RegExp() }))
+    } catch (err) {
+      error = err
+    }
+
+    assert(error)
+    assert(error.message.includes('cannot be converted') > 0)
+  })
+})

--- a/test/Clownface/dataset.js
+++ b/test/Clownface/dataset.js
@@ -6,15 +6,16 @@ const rdf = require('../support/factory')
 
 describe('.dataset', () => {
   it('should be undefined if there is no context with a dataset', () => {
-    const cf = clownface()
+    const cf = clownface({ dataset: rdf.dataset() })
+
+    cf._context = []
 
     assert.strictEqual(typeof cf.dataset, 'undefined')
   })
 
   it('should be the dataset of the context if there is only one dataset', () => {
     const dataset = rdf.dataset()
-
-    const cf = clownface(dataset)
+    const cf = clownface({ dataset })
 
     assert.strictEqual(cf.dataset, dataset)
   })
@@ -24,8 +25,7 @@ describe('.dataset', () => {
     const termB = rdf.namedNode('http://example.org/')
     const datasetA = rdf.dataset()
     const datasetB = rdf.dataset()
-
-    const cf = clownface(null, [termA, termB])
+    const cf = clownface({ dataset: rdf.dataset(), value: [termA, termB] })
 
     // TODO: should be possible with constructor or static method
     cf._context[0].dataset = datasetA

--- a/test/Clownface/datasets.js
+++ b/test/Clownface/datasets.js
@@ -7,17 +7,17 @@ const { equals } = require('rdf-dataset-ext')
 
 describe('.datasets', () => {
   it('should be an array property', () => {
-    const cf = clownface()
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert(Array.isArray(cf.datasets))
   })
 
   it('should be empty if there is no context with a dataset', () => {
-    const cf = clownface()
+    const cf = clownface({ dataset: rdf.dataset() })
 
-    const result = cf.datasets
+    cf._context = []
 
-    assert.deepStrictEqual(result, [])
+    assert.deepStrictEqual(cf.datasets, [])
   })
 
   it('should contain all datasets of the context', () => {
@@ -25,8 +25,7 @@ describe('.datasets', () => {
     const termB = rdf.namedNode('http://example.org/')
     const datasetA = rdf.dataset()
     const datasetB = rdf.dataset()
-
-    const cf = clownface(null, [termA, termB])
+    const cf = clownface({ dataset: rdf.dataset(), value: [termA, termB] })
 
     // TODO: should be possible with constructor or static method
     cf._context[0].dataset = datasetA

--- a/test/Clownface/deleteIn.js
+++ b/test/Clownface/deleteIn.js
@@ -1,60 +1,61 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const { addAll } = require('rdf-dataset-ext')
 
 describe('.deleteIn', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.deleteIn, 'function')
   })
 
-  it('should return the called object', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph)
+  it('should return the called object', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({ dataset })
 
     assert.strictEqual(cf.deleteIn(), cf)
   })
 
-  it('should remove quads based on the object value', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should remove quads based on the object value', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({
+      dataset,
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     cf.deleteIn()
 
-    assert.strictEqual(localGraph.size, 118)
+    assert.strictEqual(dataset.size, 118)
   })
 
-  it('should remove quads based on the object value and predicate', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should remove quads based on the object value and predicate', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({
+      dataset,
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     cf.deleteIn(rdf.namedNode('http://schema.org/knows'))
 
-    assert.strictEqual(localGraph.size, 119)
+    assert.strictEqual(dataset.size, 119)
   })
 
-  it('should remove quads based on the object value and multiple predicates', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should remove quads based on the object value and multiple predicates', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({
+      dataset,
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     cf.deleteIn([
       rdf.namedNode('http://schema.org/knows'),
       rdf.namedNode('http://schema.org/spouse')
     ])
 
-    assert.strictEqual(localGraph.size, 118)
+    assert.strictEqual(dataset.size, 118)
   })
 })

--- a/test/Clownface/deleteList.js
+++ b/test/Clownface/deleteList.js
@@ -2,21 +2,24 @@
 
 const assert = require('assert')
 const clownface = require('../..')
-const ns = require('../support/namespace')
 const rdf = require('../support/factory')
+const ns = require('../support/namespace')
 const { addAll } = require('rdf-dataset-ext')
 
 describe('.deleteList', () => {
   it('should be a function', () => {
-    const cf = clownface()
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.deleteList, 'function')
   })
 
   it('should throw an error if predicate parameter is missing', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({
+      dataset,
+      term: subject
+    })
 
     let touched = false
 
@@ -30,7 +33,7 @@ describe('.deleteList', () => {
   })
 
   it('should remove list quads using the context term as subject and the given predicate', () => {
-    const localGraph = rdf.dataset()
+    const dataset = rdf.dataset()
     const subject = rdf.namedNode('http://localhost:8080/data/person/mary-cooper')
     const predicate = rdf.namedNode('http://schema.org/counts')
     const predicateOther = rdf.namedNode('http://schema.org/other')
@@ -39,9 +42,12 @@ describe('.deleteList', () => {
     const first0 = rdf.blankNode()
     const first1 = rdf.blankNode()
     const other = rdf.quad(subject, predicateOther, item0)
-    const cf = clownface(localGraph, subject)
+    const cf = clownface({
+      dataset,
+      term: subject
+    })
 
-    addAll(localGraph, [
+    addAll(dataset, [
       other,
       rdf.quad(subject, predicate, first0),
       rdf.quad(first0, ns.first, item0),
@@ -52,7 +58,7 @@ describe('.deleteList', () => {
 
     cf.deleteList(predicate)
 
-    assert.strictEqual(localGraph.size, 1)
-    assert([...localGraph][0].equals(other))
+    assert.strictEqual(dataset.size, 1)
+    assert([...dataset][0].equals(other))
   })
 })

--- a/test/Clownface/deleteOut.js
+++ b/test/Clownface/deleteOut.js
@@ -1,60 +1,61 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const { addAll } = require('rdf-dataset-ext')
 
 describe('.deleteOut', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.deleteOut, 'function')
   })
 
-  it('should return the called object', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph)
+  it('should return the called object', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({ dataset })
 
     assert.strictEqual(cf.deleteOut(), cf)
   })
 
-  it('should remove quad based on the object value', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should remove quad based on the object value', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({
+      dataset,
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     cf.deleteOut()
 
-    assert.strictEqual(localGraph.size, 113)
+    assert.strictEqual(dataset.size, 113)
   })
 
-  it('should remove quad based on the object value and predicate', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should remove quad based on the object value and predicate', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({
+      dataset,
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     cf.deleteOut(rdf.namedNode('http://schema.org/knows'))
 
-    assert.strictEqual(localGraph.size, 119)
+    assert.strictEqual(dataset.size, 119)
   })
 
-  it('should remove quad based on the object value and multiple predicates', () => {
-    const localGraph = addAll(rdf.dataset(), graph)
-    const cf = clownface(localGraph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should remove quad based on the object value and multiple predicates', async () => {
+    const dataset = addAll(rdf.dataset(), await loadExample())
+    const cf = clownface({
+      dataset,
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     cf.deleteOut([
       rdf.namedNode('http://schema.org/knows'),
       rdf.namedNode('http://schema.org/spouse')
     ])
 
-    assert.strictEqual(localGraph.size, 118)
+    assert.strictEqual(dataset.size, 118)
   })
 })

--- a/test/Clownface/factory.js
+++ b/test/Clownface/factory.js
@@ -1,43 +1,42 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
-const initExample = require('../support/example')
+const rdf = require('../support/factory')
 const Clownface = require('../../lib/Clownface')
 
 describe('factory', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
-  it('should create a Dataset object', () => {
-    const cf = clownface(graph)
+  it('should create a Clownface object', () => {
+    const dataset = rdf.dataset()
+    const cf = clownface({ dataset })
 
     assert(cf instanceof Clownface)
   })
 
-  it('should create an empty context', () => {
-    const cf = clownface(graph)
+  it('should forward the dataset argument', () => {
+    const dataset = rdf.dataset()
+    const cf = clownface({ dataset })
 
     assert.strictEqual(cf._context.length, 1)
-    assert.strictEqual(cf._context[0].dataset, graph)
-    assert(!cf._context[0].graph)
-    assert(!cf._context[0].term)
+    assert.strictEqual(cf._context[0].dataset, dataset)
   })
 
-  it('should throw an error if an unknown type is given', () => {
-    let catched = false
+  it('should forward the term argument', () => {
+    const dataset = rdf.dataset()
+    const term = rdf.namedNode('http://example.org/subject')
+    const cf = clownface({ dataset, term })
 
-    try {
-      clownface(graph, new RegExp())
-    } catch (e) {
-      catched = true
-    }
+    assert.strictEqual(cf._context.length, 1)
+    assert.strictEqual(cf._context[0].term, term)
+  })
 
-    assert.strictEqual(catched, true)
+  it('should forward the value argument', () => {
+    const dataset = rdf.dataset()
+    const value = 'abc'
+    const cf = clownface({ dataset, value })
+
+    assert.strictEqual(cf._context.length, 1)
+    assert.strictEqual(cf._context[0].term.termType, 'Literal')
+    assert.strictEqual(cf._context[0].term.value, value)
   })
 })

--- a/test/Clownface/filter.js
+++ b/test/Clownface/filter.js
@@ -1,67 +1,65 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.filter', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.filter, 'function')
   })
 
   it('should return a Dataset instance', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert(cf.filter(() => true) instanceof Clownface)
   })
 
-  it('should call the function with Dataset parameter', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should call the function with Dataset parameter', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
-    cf.in(rdf.namedNode('http://schema.org/knows'))
-      .filter(item => {
-        assert(item instanceof Clownface)
+    cf.in(rdf.namedNode('http://schema.org/knows')).filter(item => {
+      assert(item instanceof Clownface)
 
-        return true
-      })
+      return true
+    })
   })
 
-  it('should call the function for each context', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should call the function for each context', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     let count = 0
 
-    cf.in(rdf.namedNode('http://schema.org/knows'))
-      .filter(() => {
-        count++
+    cf.in(rdf.namedNode('http://schema.org/knows')).filter(() => {
+      count++
 
-        return true
-      })
+      return true
+    })
 
     assert.strictEqual(count, 7)
   })
 
-  it('should filter the context based on the return value of the function', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should filter the context based on the return value of the function', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
-    const result = cf.in(rdf.namedNode('http://schema.org/knows'))
-      .filter(item => {
-        return !item.terms.every(term => {
-          return term.equals(rdf.namedNode('http://localhost:8080/data/person/howard-wolowitz'))
-        })
+    const result = cf.in(rdf.namedNode('http://schema.org/knows')).filter(item => {
+      return !item.terms.every(term => {
+        return term.equals(rdf.namedNode('http://localhost:8080/data/person/howard-wolowitz'))
       })
+    })
 
     assert.strictEqual(result._context.length, 6)
   })

--- a/test/Clownface/forEach.js
+++ b/test/Clownface/forEach.js
@@ -1,48 +1,44 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.forEach', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.forEach, 'function')
   })
 
-  it('should call the function with Dataset parameter', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should call the function with Dataset parameter', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
-    cf.in(rdf.namedNode('http://schema.org/knows'))
-      .forEach(item => {
-        assert(item instanceof Clownface)
+    cf.in(rdf.namedNode('http://schema.org/knows')).forEach(item => {
+      assert(item instanceof Clownface)
 
-        return true
-      })
+      return true
+    })
   })
 
-  it('should call the function for each context', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should call the function for each context', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     let count = 0
 
-    cf.in(rdf.namedNode('http://schema.org/knows'))
-      .forEach(() => {
-        count++
+    cf.in(rdf.namedNode('http://schema.org/knows')).forEach(() => {
+      count++
 
-        return true
-      })
+      return true
+    })
 
     assert.strictEqual(count, 7)
   })

--- a/test/Clownface/has.js
+++ b/test/Clownface/has.js
@@ -1,29 +1,21 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.has', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.has, 'function')
   })
 
-  it('should return a new Dataset instance', () => {
+  it('should return a new Dataset instance', async () => {
     const predicate = rdf.namedNode('http://schema.org/givenName')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.has(predicate, 'Stuart')
 
@@ -31,19 +23,20 @@ describe('.has', () => {
     assert.notStrictEqual(result, cf)
   })
 
-  it('should use the dataset from the context', () => {
+  it('should use the dataset from the context', async () => {
+    const dataset = await loadExample()
     const predicate = rdf.namedNode('http://schema.org/givenName')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset })
 
     const result = cf.has(predicate, 'Stuart')
 
-    assert.strictEqual(result._context[0].dataset, graph)
+    assert.strictEqual(result._context[0].dataset, dataset)
   })
 
-  it('should use the found subject in the context', () => {
+  it('should use the found subject in the context', async () => {
     const subject = rdf.namedNode('http://localhost:8080/data/person/stuart-bloom')
     const predicate = rdf.namedNode('http://schema.org/givenName')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.has(predicate, 'Stuart')
 
@@ -51,29 +44,29 @@ describe('.has', () => {
     assert(subject.equals(result._context[0].term))
   })
 
-  it('should support multiple predicates in an array', () => {
+  it('should support multiple predicates in an array', async () => {
     const predicateA = rdf.namedNode('http://schema.org/knows')
     const predicateB = rdf.namedNode('http://schema.org/spouse')
     const object = rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.has([predicateA, predicateB], object)
 
     assert.strictEqual(result._context.length, 8)
   })
 
-  it('should support multiple predicates in an array', () => {
+  it('should support multiple predicates in an array', async () => {
     const predicate = rdf.namedNode('http://schema.org/givenName')
     const objectA = rdf.literal('Leonard')
     const objectB = rdf.literal('Sheldon')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.has(predicate, [objectA, objectB])
 
     assert.strictEqual(result._context.length, 2)
   })
 
-  it('should use context term as subject', () => {
+  it('should use context term as subject', async () => {
     const subjectA = rdf.namedNode('http://localhost:8080/data/person/sheldon-cooper')
     const subjectB = rdf.namedNode('http://localhost:8080/data/person/stuart-bloom')
     const predicate = rdf.namedNode('http://schema.org/givenName')
@@ -82,7 +75,7 @@ describe('.has', () => {
       rdf.literal('Sheldon')
     ]
 
-    const cf = clownface(graph, [subjectA, subjectB])
+    const cf = clownface({ dataset: await loadExample(), term: [subjectA, subjectB] })
 
     const result = cf.has(predicate, objects)
 

--- a/test/Clownface/in.js
+++ b/test/Clownface/in.js
@@ -1,28 +1,23 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.in', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.in, 'function')
   })
 
-  it('should return a new Dataset instance', () => {
-    const cf = clownface(graph, '2311 North Los Robles Avenue, Aparment 4A')
+  it('should return a new Dataset instance', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      value: '2311 North Los Robles Avenue, Aparment 4A'
+    })
 
     const result = cf.in(rdf.namedNode('http://schema.org/streetAddress'))
 
@@ -30,8 +25,11 @@ describe('.in', () => {
     assert.notStrictEqual(result, cf)
   })
 
-  it('should search object -> subject', () => {
-    const cf = clownface(graph, '2311 North Los Robles Avenue, Aparment 4A')
+  it('should search object -> subject', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      value: '2311 North Los Robles Avenue, Aparment 4A'
+    })
 
     const result = cf.in(rdf.namedNode('http://schema.org/streetAddress'))
 
@@ -39,8 +37,11 @@ describe('.in', () => {
     assert.strictEqual(result._context[0].term.termType, 'BlankNode')
   })
 
-  it('should support multiple predicate values in an array', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should support multiple predicate values in an array', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     const result = cf.in([
       rdf.namedNode('http://schema.org/spouse'),
@@ -50,8 +51,11 @@ describe('.in', () => {
     assert.strictEqual(result._context.length, 8)
   })
 
-  it('should support clownface objects as predicates', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should support clownface objects as predicates', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     const result = cf.in(cf.node([
       rdf.namedNode('http://schema.org/spouse'),

--- a/test/Clownface/index.js
+++ b/test/Clownface/index.js
@@ -1,6 +1,7 @@
 /* global describe */
 
 describe('Clownface', () => {
+  require('./constructor')
   require('./factory')
   require('./term')
   require('./terms')

--- a/test/Clownface/list.js
+++ b/test/Clownface/list.js
@@ -6,36 +6,36 @@ const rdf = require('../support/factory')
 const ns = require('../support/namespace')
 const { addAll } = require('rdf-dataset-ext')
 
+function listDataset () {
+  const start = rdf.blankNode()
+  const item = [rdf.blankNode(), rdf.blankNode(), rdf.blankNode()]
+
+  return rdf.dataset([
+    rdf.quad(start, ns.list, item[0]),
+    rdf.quad(item[0], ns.first, rdf.literal('1')),
+    rdf.quad(item[0], ns.rest, item[1]),
+    rdf.quad(item[1], ns.first, rdf.literal('2')),
+    rdf.quad(item[1], ns.rest, item[2]),
+    rdf.quad(item[2], ns.first, rdf.literal('3')),
+    rdf.quad(item[2], ns.rest, ns.nil)
+  ])
+}
+
 describe('.list', () => {
-  const listGraph = () => {
-    const start = rdf.blankNode()
-    const item = [rdf.blankNode(), rdf.blankNode(), rdf.blankNode()]
-
-    return rdf.dataset([
-      rdf.quad(start, ns.list, item[0]),
-      rdf.quad(item[0], ns.first, rdf.literal('1')),
-      rdf.quad(item[0], ns.rest, item[1]),
-      rdf.quad(item[1], ns.first, rdf.literal('2')),
-      rdf.quad(item[1], ns.rest, item[2]),
-      rdf.quad(item[2], ns.first, rdf.literal('3')),
-      rdf.quad(item[2], ns.rest, ns.nil)
-    ])
-  }
-
   it('should be a function', () => {
-    const cf = clownface(listGraph())
+    const cf = clownface({ dataset: listDataset() })
 
     assert.strictEqual(typeof cf.list, 'function')
   })
 
   it('should return an iterator', () => {
-    const cf = clownface(listGraph())
+    const cf = clownface({ dataset: listDataset() })
 
     assert.strictEqual(typeof cf.out(ns.list).list()[Symbol.iterator], 'function')
   })
 
   it('should iterate over a single term context', () => {
-    const cf = clownface(listGraph())
+    const cf = clownface({ dataset: listDataset() })
 
     const result = []
 
@@ -47,7 +47,7 @@ describe('.list', () => {
   })
 
   it('should not iterate over a multiple term context', () => {
-    const cf = clownface(addAll(listGraph(), listGraph()))
+    const cf = clownface({ dataset: addAll(listDataset(), listDataset()) })
 
     let list
     let touched = false
@@ -63,11 +63,11 @@ describe('.list', () => {
   })
 
   it('should return empty iterator when no list exists', () => {
-    const cf = clownface(listGraph())
+    const cf = clownface({ dataset: listDataset() })
 
     const list = cf.out(rdf.namedNode('http://example.com/not-list')).list()[Symbol.iterator]()
-
     const first = list.next()
+
     assert.strictEqual(first.done, true)
   })
 })

--- a/test/Clownface/literal.js
+++ b/test/Clownface/literal.js
@@ -1,29 +1,20 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
-const rdf = require('rdf-ext')
-const rdfDataModel = require('@rdfjs/data-model')
-const initExample = require('../support/example')
+const loadExample = require('../support/example')
+const rdf = require('../support/factory')
 const Clownface = require('../../lib/Clownface')
 
 describe('.literal', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.literal, 'function')
   })
 
   it('should return a new Clownface instance', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal('example')
 
@@ -32,16 +23,17 @@ describe('.literal', () => {
   })
 
   it('should use the dataset from the context', () => {
-    const cf = clownface(graph)
+    const dataset = rdf.dataset()
+    const cf = clownface({ dataset })
 
     const result = cf.literal('example')
 
-    assert.strictEqual(result._context[0].dataset, graph)
+    assert.strictEqual(result._context[0].dataset, dataset)
   })
 
-  it('should use the given string as Literal', () => {
+  it('should use the given string as Literal', async () => {
     const value = '2311 North Los Robles Avenue, Aparment 4A'
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.literal(value)
 
@@ -52,7 +44,7 @@ describe('.literal', () => {
 
   it('should use the given double number as Literal', () => {
     const value = 1.23
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal(value)
 
@@ -64,7 +56,7 @@ describe('.literal', () => {
 
   it('should use the given integer number as Literal', () => {
     const value = 123
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal(value)
 
@@ -76,7 +68,7 @@ describe('.literal', () => {
 
   it('should use the given boolean as Literal', () => {
     const value = true
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal(value)
 
@@ -87,7 +79,7 @@ describe('.literal', () => {
   })
 
   it('should support multiple values in an array', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal(['1', '2'])
 
@@ -100,7 +92,7 @@ describe('.literal', () => {
 
   it('should use the given datatype', () => {
     const datatypeIri = 'http://example.org/datatype'
-    const cf = clownface(rdf.dataset())
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal('example', datatypeIri)
 
@@ -111,8 +103,8 @@ describe('.literal', () => {
   })
 
   it('should accept rdfjs NamedNodes as datatype', () => {
-    const datatype = rdfDataModel.namedNode('http://example.org/datatype')
-    const cf = clownface(rdf.dataset())
+    const datatype = rdf.namedNode('http://example.org/datatype')
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal('example', datatype)
 
@@ -124,7 +116,7 @@ describe('.literal', () => {
 
   it('should use the given language', () => {
     const language = 'en'
-    const cf = clownface(rdf.dataset())
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.literal('example', language)
 

--- a/test/Clownface/map.js
+++ b/test/Clownface/map.js
@@ -1,66 +1,61 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.map', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.map, 'function')
   })
 
   it('should return an Array', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert(Array.isArray(cf.map(item => item)))
   })
 
-  it('should call the function with Dataset parameter', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should call the function with Dataset parameter', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
-    cf.in(rdf.namedNode('http://schema.org/knows'))
-      .map(item => {
-        assert(item instanceof Clownface)
+    cf.in(rdf.namedNode('http://schema.org/knows')).map(item => {
+      assert(item instanceof Clownface)
 
-        return true
-      })
+      return true
+    })
   })
 
-  it('should call the function for each context', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should call the function for each context', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     let count = 0
 
-    cf.in(rdf.namedNode('http://schema.org/knows'))
-      .map(() => {
-        count++
+    cf.in(rdf.namedNode('http://schema.org/knows')).map(() => {
+      count++
 
-        return true
-      })
+      return true
+    })
 
     assert.strictEqual(count, 7)
   })
 
-  it('should return an array of all return values', () => {
-    const cf = clownface(graph)
+  it('should return an array of all return values', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
-    const result = cf.node(rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
-      .in(rdf.namedNode('http://schema.org/knows'))
-      .map((item, index) => {
-        return index
-      })
+    const result = cf.in(rdf.namedNode('http://schema.org/knows')).map((item, index) => index)
 
     assert.deepStrictEqual(result, [0, 1, 2, 3, 4, 5, 6])
   })

--- a/test/Clownface/namedNode.js
+++ b/test/Clownface/namedNode.js
@@ -1,27 +1,19 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
-const initExample = require('../support/example')
+const rdf = require('../support/factory')
 const Clownface = require('../../lib/Clownface')
 
 describe('.namedNode', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.namedNode, 'function')
   })
 
   it('should return a new Clownface instance', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.namedNode('http://localhost:8080/data/person/stuart-bloom')
 
@@ -30,16 +22,17 @@ describe('.namedNode', () => {
   })
 
   it('should use the dataset from the context', () => {
-    const cf = clownface(graph)
+    const dataset = rdf.dataset()
+    const cf = clownface({ dataset })
 
     const result = cf.namedNode('http://localhost:8080/data/person/stuart-bloom')
 
-    assert.strictEqual(result._context[0].dataset, graph)
+    assert.strictEqual(result._context[0].dataset, dataset)
   })
 
   it('should use the given string as IRI for the Named Node', () => {
     const iri = 'http://localhost:8080/data/person/stuart-bloom'
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.namedNode(iri)
 
@@ -51,7 +44,7 @@ describe('.namedNode', () => {
   it('should support multiple values in an array', () => {
     const iriA = 'http://example.org/a'
     const iriB = 'http://example.org/b'
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.namedNode([iriA, iriB])
 

--- a/test/Clownface/node.js
+++ b/test/Clownface/node.js
@@ -1,30 +1,21 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const rdfDataModel = require('@rdfjs/data-model')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.node', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
-  it('should be a function', () => {
-    const cf = clownface(graph)
+  it('should be a function', async () => {
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.node, 'function')
   })
 
-  it('should return a new Dataset instance', () => {
+  it('should return a new Dataset instance', async () => {
     const term = rdf.namedNode('http://localhost:8080/data/person/stuart-bloom')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.node(term)
 
@@ -32,18 +23,19 @@ describe('.node', () => {
     assert.notStrictEqual(result, cf)
   })
 
-  it('should use the dataset from the context', () => {
+  it('should use the dataset from the context', async () => {
+    const dataset = await loadExample()
     const term = rdf.namedNode('http://localhost:8080/data/person/stuart-bloom')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset })
 
     const result = cf.node(term)
 
-    assert.strictEqual(result._context[0].dataset, graph)
+    assert.strictEqual(result._context[0].dataset, dataset)
   })
 
-  it('should use the given Named Node', () => {
+  it('should use the given Named Node', async () => {
     const term = rdf.namedNode('http://localhost:8080/data/person/stuart-bloom')
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.node(term)
 
@@ -51,9 +43,9 @@ describe('.node', () => {
     assert(term.equals(result._context[0].term))
   })
 
-  it('should use the given string as Literal', () => {
+  it('should use the given string as Literal', async () => {
     const value = '2311 North Los Robles Avenue, Aparment 4A'
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.node(value)
 
@@ -62,8 +54,8 @@ describe('.node', () => {
     assert.strictEqual(result._context[0].term.value, value)
   })
 
-  it('should use the given number as Literal', () => {
-    const cf = clownface(graph)
+  it('should use the given number as Literal', async () => {
+    const cf = clownface({ dataset: await loadExample() })
 
     const result = cf.node(123)
 
@@ -73,7 +65,7 @@ describe('.node', () => {
   })
 
   it('should throw an error if an unknown type is given', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     let result
     let catched = false
@@ -89,7 +81,7 @@ describe('.node', () => {
   })
 
   it('should support multiple values in an array', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.node(['1', '2'])
 
@@ -101,7 +93,7 @@ describe('.node', () => {
   })
 
   it('should create Named Node context if type is NamedNode', () => {
-    const cf = clownface(rdf.dataset())
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.node('http://example.org/', { type: 'NamedNode' })
 
@@ -110,7 +102,7 @@ describe('.node', () => {
   })
 
   it('should create Blank Node context if type is BlankNode', () => {
-    const cf = clownface(rdf.dataset())
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.node(null, { type: 'BlankNode' })
 
@@ -120,7 +112,7 @@ describe('.node', () => {
 
   it('should use the given datatype', () => {
     const datatype = rdf.namedNode('http://example.org/datatype')
-    const cf = clownface(rdf.dataset())
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.node('example', { datatype: datatype.value })
 
@@ -131,8 +123,8 @@ describe('.node', () => {
   })
 
   it('should accept rdfjs NamedNodes as datatype', () => {
-    const datatype = rdfDataModel.namedNode('http://example.org/datatype')
-    const cf = clownface(rdf.dataset())
+    const datatype = rdf.namedNode('http://example.org/datatype')
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.node('example', { datatype: datatype })
 

--- a/test/Clownface/out.js
+++ b/test/Clownface/out.js
@@ -1,28 +1,23 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.out', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.out, 'function')
   })
 
-  it('should return a new Dataset instance', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/amy-farrah-fowler'))
+  it('should return a new Dataset instance', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
+    })
 
     const result = cf.out(rdf.namedNode('http://schema.org/jobTitle'))
 
@@ -30,8 +25,11 @@ describe('.out', () => {
     assert.notStrictEqual(result, cf)
   })
 
-  it('should search subject -> object', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/amy-farrah-fowler'))
+  it('should search subject -> object', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/amy-farrah-fowler')
+    })
 
     const result = cf.out(rdf.namedNode('http://schema.org/jobTitle'))
 
@@ -40,8 +38,11 @@ describe('.out', () => {
     assert.strictEqual(result._context[0].term.value, 'neurobiologist')
   })
 
-  it('should support multiple predicate values in an array', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should support multiple predicate values in an array', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     const result = cf.out([
       rdf.namedNode('http://schema.org/familyName'),
@@ -51,8 +52,11 @@ describe('.out', () => {
     assert.strictEqual(result._context.length, 2)
   })
 
-  it('should support clownface objects as predicates', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should support clownface objects as predicates', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     const result = cf.out(cf.node([
       rdf.namedNode('http://schema.org/familyName'),

--- a/test/Clownface/term.js
+++ b/test/Clownface/term.js
@@ -1,29 +1,19 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 
 describe('.term', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be undefined if there is no context with a term', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.term, 'undefined')
   })
 
   it('should be the term of the context if there is only one term', () => {
     const term = rdf.literal('1')
-
-    const cf = clownface(graph, term)
+    const cf = clownface({ dataset: rdf.dataset(), term })
 
     assert(term.equals(cf.term))
   })
@@ -32,7 +22,7 @@ describe('.term', () => {
     const termA = rdf.literal('1')
     const termB = rdf.namedNode('http://example.org/')
 
-    const cf = clownface(graph, [termA, termB])
+    const cf = clownface({ dataset: rdf.dataset(), terms: [termA, termB] })
 
     assert.strictEqual(typeof cf.term, 'undefined')
   })

--- a/test/Clownface/term.js
+++ b/test/Clownface/term.js
@@ -22,7 +22,7 @@ describe('.term', () => {
     const termA = rdf.literal('1')
     const termB = rdf.namedNode('http://example.org/')
 
-    const cf = clownface({ dataset: rdf.dataset(), terms: [termA, termB] })
+    const cf = clownface({ dataset: rdf.dataset(), term: [termA, termB] })
 
     assert.strictEqual(typeof cf.term, 'undefined')
   })

--- a/test/Clownface/terms.js
+++ b/test/Clownface/terms.js
@@ -1,27 +1,18 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 
 describe('.terms', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be an array property', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert(Array.isArray(cf.terms))
   })
 
   it('should be empty if there is no context with a term', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     const result = cf.terms
 
@@ -31,8 +22,7 @@ describe('.terms', () => {
   it('should contain all terms of the context', () => {
     const termA = rdf.literal('1')
     const termB = rdf.namedNode('http://example.org/')
-
-    const cf = clownface(graph, [termA, termB])
+    const cf = clownface({ dataset: rdf.dataset(), term: [termA, termB] })
 
     const result = cf.terms
 

--- a/test/Clownface/toArray.js
+++ b/test/Clownface/toArray.js
@@ -1,34 +1,29 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 const Clownface = require('../../lib/Clownface')
 
 describe('.toArray', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.toArray, 'function')
   })
 
   it('should return an array', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert(Array.isArray(cf.toArray()))
   })
 
-  it('should return a Dataset instance for every context object', () => {
-    const cf = clownface(graph, rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
+  it('should return a Dataset instance for every context object', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
     const result = cf.in(rdf.namedNode('http://schema.org/knows')).toArray()
 

--- a/test/Clownface/toString.js
+++ b/test/Clownface/toString.js
@@ -1,50 +1,44 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
+const loadExample = require('../support/example')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 
 describe('.toString', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be a function', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.toString, 'function')
   })
 
   it('should return a string', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.toString(), 'string')
   })
 
-  it('should return the value of a single term', () => {
-    const cf = clownface(graph)
+  it('should return the value of a single term', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski')
+    })
 
-    const result = cf.node(rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'))
-      .out(rdf.namedNode('http://schema.org/givenName'))
-      .toString()
+    const result = cf.out(rdf.namedNode('http://schema.org/givenName')).toString()
 
     assert.strictEqual(result, 'Bernadette')
   })
 
-  it('should return comma separated values if multiple terms', () => {
-    const cf = clownface(graph)
+  it('should return comma separated values if multiple terms', async () => {
+    const cf = clownface({
+      dataset: await loadExample(),
+      term: [
+        rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'),
+        rdf.namedNode('http://localhost:8080/data/person/howard-wolowitz')
+      ]
+    })
 
-    const givenName = cf.node([
-      rdf.namedNode('http://localhost:8080/data/person/bernadette-rostenkowski'),
-      rdf.namedNode('http://localhost:8080/data/person/howard-wolowitz')
-    ])
-      .out(rdf.namedNode('http://schema.org/givenName'))
-      .toString()
+    const givenName = cf.out(rdf.namedNode('http://schema.org/givenName')).toString()
 
     assert.strictEqual(givenName, 'Bernadette,Howard')
   })

--- a/test/Clownface/value.js
+++ b/test/Clownface/value.js
@@ -1,29 +1,19 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 
 describe('.value', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be undefined if there is no context with a term', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.strictEqual(typeof cf.value, 'undefined')
   })
 
   it('should be the value of the context if there is only one term', () => {
     const term = rdf.literal('1')
-
-    const cf = clownface(graph, term)
+    const cf = clownface({ dataset: rdf.dataset(), value: term.value })
 
     assert.strictEqual(cf.value, term.value)
   })
@@ -31,8 +21,7 @@ describe('.value', () => {
   it('should be undefined if there are multiple terms in the context', () => {
     const termA = rdf.literal('1')
     const termB = rdf.namedNode('http://example.org/')
-
-    const cf = clownface(graph, [termA, termB])
+    const cf = clownface({ dataset: rdf.dataset(), terms: [termA, termB] })
 
     assert.strictEqual(typeof cf.value, 'undefined')
   })

--- a/test/Clownface/value.js
+++ b/test/Clownface/value.js
@@ -21,7 +21,7 @@ describe('.value', () => {
   it('should be undefined if there are multiple terms in the context', () => {
     const termA = rdf.literal('1')
     const termB = rdf.namedNode('http://example.org/')
-    const cf = clownface({ dataset: rdf.dataset(), terms: [termA, termB] })
+    const cf = clownface({ dataset: rdf.dataset(), term: [termA, termB] })
 
     assert.strictEqual(typeof cf.value, 'undefined')
   })

--- a/test/Clownface/values.js
+++ b/test/Clownface/values.js
@@ -1,27 +1,18 @@
-/* global before, describe, it */
+/* global describe, it */
 
 const assert = require('assert')
 const clownface = require('../..')
 const rdf = require('../support/factory')
-const initExample = require('../support/example')
 
 describe('.values', () => {
-  let graph
-
-  before(() => {
-    return initExample().then(dataset => {
-      graph = dataset
-    })
-  })
-
   it('should be an array property', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert(Array.isArray(cf.values))
   })
 
   it('should be empty if there is no context with a term', () => {
-    const cf = clownface(graph)
+    const cf = clownface({ dataset: rdf.dataset() })
 
     assert.deepStrictEqual(cf.values, [])
   })
@@ -29,8 +20,7 @@ describe('.values', () => {
   it('should contain the values of the terms', () => {
     const termA = rdf.literal('1')
     const termB = rdf.namedNode('http://example.org/')
-
-    const cf = clownface(graph, [termA, termB])
+    const cf = clownface({ dataset: rdf.dataset(), value: [termA, termB] })
 
     const result = cf.values
 


### PR DESCRIPTION
This PR changes the interface of the factory and constructor to use named arguments. The following arguments are supported:

- `dataset`: The dataset to traverse (first argument in the old interface)
- `graph`: The named graph of the dataset which should be used (named argument in the old interface)
- `term`: One RDF/JS Term or an array of RDF/JS terms which should be used as starting point (new argument for consistency with "graph pointer" like in rdf loaders and rdf-path)
- `value`: One value or an array of values which should be converted to RDF/JS Terms and should be used as starting points (second argument in the old interface)
- `_context`: Existing context for cloning a clownface object (named argument in the old interface)

This is a breaking change (in a 0.x.x version), but it should be done cause: 

- the interface will be more consistent when used together with the `graph` argument
- cloning Clownface objects can be done by simply calling the factory with the object to clone as argument
- "graph pointer" objects like they are used in rdf loaders and [rdf-path](https://github.com/bergos/rdf-path) can be easier converted to Clownface objects

Most changes are in the tests, cause the factory to create the objects must be called in a different way. For reviewing mainly have a look at `index.js`, `Clownface.js` and in tests `constructor.js` `factory.js`.

fixes #14 and #15